### PR TITLE
feat: add support for `expireIn` option

### DIFF
--- a/batchedAtomic.ts
+++ b/batchedAtomic.ts
@@ -87,8 +87,8 @@ export class BatchedAtomicOperation {
    * Add to the operation a mutation that sets the value of the specified key
    * to the specified value if all checks pass during the commit.
    */
-  set(key: Deno.KvKey, value: unknown): this {
-    return this.#enqueue("set", [key, value]);
+  set(key: Deno.KvKey, value: unknown, options?: { expireIn?: number }): this {
+    return this.#enqueue("set", [key, value, options]);
   }
 
   /**


### PR DESCRIPTION
This PR lets users configure the `expireIn` option that was recently added to [`Deno.AtomicOperation.prototype.set`](https://deno.land/api@v1.36.4?s=Deno.AtomicOperation&unstable=&p=prototype.set#function_set_0_parameters_options) and [`Deno.Kv.prototype.set`](https://deno.land/api@v1.36.4?s=Deno.AtomicOperation&unstable=&p=prototype.set#function_set_0_parameters_options).

I wasn't sure if I should add tests for this feature, so I'd like to hear your opinion.

Fix #3.