### PR TITLE
docs: add usage notes and link to deno.land docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,26 @@
 
 A set of tools for working with Deno KV.
 
-## Batched Atomic
+## Usage
+
+To import `kv-toolbox` into your Deno project, select one of the available modules and import them like so:
+
+keys: `import * as mod from "https://deno.land/x/kv_toolbox/keys.ts";`
+
+blob: `import * as mod from "https://deno.land/x/kv_toolbox/blob.ts";`
+
+batched\_atomic: `import * as mod from "https://deno.land/x/kv_toolbox/batched_atomic.ts";`
+
+Method imports are also available. For more details, see the [full documentation here](https://deno.land/x/kv_toolbox?doc).
+
+## Functionality overview
+
+### Batched Atomic
 
 A set of APIs for dealing with the limitation of atomic commit sized in Deno KV,
 where currently only 10 operations operations can be part of a commit.
 
-### `batchedAtomic()`
+#### `batchedAtomic()`
 
 Similar to `Deno.Kv#atomic()`, but will batch individual transactions across as
 many atomic operations as necessary.
@@ -15,7 +29,7 @@ many atomic operations as necessary.
 The `commit()` method will return a promise which resolves with an array of
 results based on how many batches the operations was broken up into.
 
-## Blob
+### Blob
 
 A set of APIs for storing arbitrarily sized blobs in Deno KV. Currently Deno KV
 has a limit of key values being 64k. The `set()` function breaks down a blob
@@ -23,7 +37,7 @@ into chunks and manages sub-keys to store the complete value. The `get()`
 function reverses that process, and `remove()` will delete the key, sub-keys and
 values.
 
-### `set()`
+#### `set()`
 
 Similar to `Deno.Kv.prototype.set()`, in that it stores a blob value with an
 associated key. In order to deal with the size limitations of values, `set()`
@@ -31,7 +45,7 @@ will transparently chunk up the blob into parts that can be handled by Deno KV.
 
 The blob can be a byte `ReadableStream` or array buffer like.
 
-### `get()`
+#### `get()`
 
 Similar to `Deno.Kv.prototype.get()`, in that it retrieves a blob value based on
 the provided key. If a previous blob value has been set with `set()`, it will be
@@ -40,34 +54,34 @@ retrieved.
 By default the value is resolved as a `Uint8Array` but if the option `stream` is
 set to `true`, then a byte `ReadableStream` is provided to read out the blob.
 
-### `remove()`
+#### `remove()`
 
 Similar to `Deno.Kv.prototype.delete()`, in that it deletes a blob key and value
 form the data store. If a blob value isn't stored for the given key, it resolves
 in a noop.
 
-## Keys
+### Keys
 
 APIs for dealing with Deno KV keys.
 
-### `equals()`
+#### `equals()`
 
 Compares the quality of two `Deno.KvKey`s, returning `true` if they are equal
 and `false` if they are not. This is more specialized than other forms of deeply
 equal comparison.
 
-### `startsWith()`
+#### `startsWith()`
 
 Determines if the `key` starts with the `prefix` provided, returning `true` if
 it does, otherwise `false`.
 
-### `keys()`
+#### `keys()`
 
 Similar to `Deno.Kv.prototype.list()`, in that is takes a selector, but instead
 of returning an async iterator of matched values, it resolves with an array of
 matching keys.
 
-### `unique()`
+#### `unique()`
 
 Resolves with an array of unique sub keys/prefixes for the provided prefix.
 
@@ -75,7 +89,7 @@ This is useful when storing keys and values in a hierarchical/tree view, where
 you are retrieving a list and you want to know all the unique _descendants_ of a
 key in order to be able to enumerate them.
 
-### `uniqueCount()`
+#### `uniqueCount()`
 
 Resolves with an array of values which contain the unique sub keys/prefixes for
 the provided prefix along with a count of how many keys there are.


### PR DESCRIPTION
Hey! Thanks for making `kv-toolbox`. It is super helpful.

I've added some notes to the docs and increased a level of nesting.