### PR TITLE
feat: implement batching for `mutate`

### DIFF
--- a/batched_atomic.test.ts
+++ b/batched_atomic.test.ts
@@ -155,3 +155,22 @@ Deno.test({
     return teardown();
   },
 });
+
+Deno.test({
+  name: "batched atomic mutate handles many items",
+  async fn() {
+    const kv = await setup();
+    const items = Array
+      .from({ length: 1000 }, (_, index) => index)
+      .map((i) => ({
+        key: [i],
+        value: "x".repeat(2000),
+        type: "set" as const,
+      }));
+    const op = batchedAtomic(kv);
+    op.mutate(...items);
+    const actual = await op.commit();
+    assert(actual.every(({ ok }) => ok));
+    return teardown();
+  },
+});


### PR DESCRIPTION
This attempts to implement batching for the `mutate` method of an atomic transaction, which currently despite the docs saying so wasn't implemented yet.

This passes the mutation arguments to `mutate` through to the individual mutation methods `set`, `delete`, `sum`, `max`, `min`, effectively making `mutate` a shorthand for chained calls to the individual mutation methods. This avoids having to add more complex batching logic in `commit` specifically for `mutate`, since `commit` already handles batching for the individual mutation methods.

Not sure if this is the right approach and if this maintains consistency of the transaction.

Fixes #17.